### PR TITLE
Downgrade ASIO version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/websocketpp"]
 	path = deps/websocketpp
 	url = https://github.com/zaphoyd/websocketpp.git
+[submodule "deps/asio"]
+	path = deps/asio
+	url = https://github.com/chriskohlhoff/asio.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "deps/websocketpp"]
 	path = deps/websocketpp
 	url = https://github.com/zaphoyd/websocketpp.git
-[submodule "deps/asio"]
-	path = deps/asio
-	url = https://github.com/chriskohlhoff/asio.git

--- a/src/obs-websocket.cpp
+++ b/src/obs-websocket.cpp
@@ -65,19 +65,6 @@ bool obs_module_load(void) {
 	_eventsSystem = WSEventsPtr(new WSEvents(_server));
 
 
-	
-#ifndef _WIN32
-	//Prevent OBS Websocket from running
-	{
-		config_t* obsConfig = obs_frontend_get_profile_config();
-		if(config_get_bool(obsConfig, "WebsocketAPI", "ServerEnabled"))
-		{
-			config_set_bool(obsConfig, "WebsocketAPI", "ServerEnabled", false);
-			config_save(obsConfig);
-		}
-	}
-#endif
-
 	// UI setup
 	obs_frontend_push_ui_translation(obs_module_get_string);
 	QMainWindow* mainWindow = (QMainWindow*)obs_frontend_get_main_window();


### PR DESCRIPTION
We got some reports that people were getting crashes on MacOS with obs-websocket. This is due to ASIO version mismatches in the same process, specifically in the kqueue_reactor module. There is an open Issue report for it, but the bug is still unpatched.

This PR downgrades ASIO to 1.12.1, which all other plugins have standardized on right now, and removes the logic to disable obs-websocket.